### PR TITLE
Movie exception and new /movie syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,38 @@ Michael Lutsik | Dev
 
 ## Use
 
+Run the `ApiApplication` file and visit `localhost:8080`.
+
 ### Endpoints
 
-URI | Description | Options
---- | --- | ---
-`/hello` | Test endpoint to make sure that the project is working correctly, optionally takes `name` parameter. | `?name=`
-`/all` | Returns all Movies |
-`/movie` | Returns a specific movie by title | `?title=`
+#### `/hello`
+
+This is a test endpoint to make sure that project is working correctly.
+It optionally takes a parameter `name`.
+
+For example:
+
+```
+localhost:8080/hello?name=World
+```
+
+#### `/all`
+
+This is an endpoint that returns all movies available.
+
+For example:
+
+```
+localhost:8080/all
+```
+
+#### `/movie`
+
+This is an endpoint that returns a specific movie by title.
+It uses the syntax `/movie/title`
+
+For example:
+
+```
+localhost:8080/movie/titanic
+```

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -1,5 +1,6 @@
 package api;
 
+import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -8,7 +9,7 @@ import java.util.ArrayList;
  * Oscars API Controller
  */
 @RestController
-public class Controller
+public class Controller implements ErrorController
 {
     /**
      * A test endpoint to make sure that the API is running.
@@ -48,9 +49,32 @@ public class Controller
         return m;
     }
 
+    /**
+     * Basic /error endpoint
+     *
+     * @return Error object with "Endpoint not found" message and 404 code
+     */
+    @GetMapping("/error")
+    public Error error()
+    {
+        return new Error("Endpoint not found", 404);
+    }
+
+    /**
+     * Handles the MovieNotFoundException thrown when /movie can't find the specific title
+     *
+     * @param e MovieNotFoundException
+     * @return Error object with 404 code
+     */
     @ExceptionHandler(MovieNotFoundException.class)
     public Error handleMovieNotFound(MovieNotFoundException e)
     {
         return new Error(e.getMessage(), 404);
+    }
+
+    @Override
+    public String getErrorPath()
+    {
+        return "/error";
     }
 }

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -1,8 +1,6 @@
 package api;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 
@@ -42,15 +40,17 @@ public class Controller
      * @param title the title of the movie, use ?title=
      * @return a Movie
      */
-    @GetMapping("/movie")
-    public Movie movie(@RequestParam(value = "title", defaultValue = "null") String title)
+    @GetMapping("/movie/{title}")
+    public Movie movie(@PathVariable("title") String title) throws MovieNotFoundException
     {
-        if (title.equals("null"))
-        {
-            return new Movie("0", "No title given", "0");
-        }
         Movie m = FetchFromCSV.certainMovie(title).get(0);
         m.updateFields();
         return m;
+    }
+
+    @ExceptionHandler(MovieNotFoundException.class)
+    public Error handleMovieNotFound(MovieNotFoundException e)
+    {
+        return new Error(e.getMessage(), 404);
     }
 }

--- a/src/main/java/api/Error.java
+++ b/src/main/java/api/Error.java
@@ -1,0 +1,42 @@
+package api;
+
+/**
+ * Error class
+ */
+public class Error
+{
+    private String error;
+    private int status_code;
+
+    /**
+     * Create error with message and status code
+     *
+     * @param error       message as String
+     * @param status_code status code as int
+     */
+    public Error(String error, int status_code)
+    {
+        this.error = error;
+        this.status_code = status_code;
+    }
+
+    /**
+     * Gets the Error's message
+     *
+     * @return error message as String
+     */
+    public String getError()
+    {
+        return error;
+    }
+
+    /**
+     * Gets the Error's status code
+     *
+     * @return status code as int
+     */
+    public int getStatus_code()
+    {
+        return status_code;
+    }
+}

--- a/src/main/java/api/FetchFromCSV.java
+++ b/src/main/java/api/FetchFromCSV.java
@@ -51,13 +51,20 @@ public class FetchFromCSV
                     movieData.get(movieData.indexOf(one)).addAward(new Award(category, name, winner));
                 }
             }
-            System.out.println(movieData);
         }
         catch (IOException e)
         {
             e.printStackTrace();
         }
-        return movieData;
+        // check to see if a match was found
+        if (movieData.size() == 0)
+        {
+            throw new MovieNotFoundException();
+        }
+        else
+        {
+            return movieData;
+        }
     }
 
     public static ArrayList<Movie> all()
@@ -103,7 +110,6 @@ public class FetchFromCSV
                     movieData.get(movieData.indexOf(one)).addAward(new Award(category, name, winner));
                 }
             }
-            System.out.println(movieData);
         }
         catch (IOException e)
         {

--- a/src/main/java/api/MovieNotFoundException.java
+++ b/src/main/java/api/MovieNotFoundException.java
@@ -1,0 +1,13 @@
+package api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class MovieNotFoundException extends RuntimeException
+{
+    public MovieNotFoundException()
+    {
+        super("Movie not found");
+    }
+}


### PR DESCRIPTION
The `/movie` endpoint has a new simpler syntax. For example if searching for Titanic:

```
localhost:8080/movie/titanic
```

This also handles the 500 error encountered when the Movie isn't found.