### PR TITLE
Category search

### DIFF
--- a/DELIVERABLES.md
+++ b/DELIVERABLES.md
@@ -8,7 +8,8 @@
     - The `/all` endpoint returns a collection resource in JSON.
 - [x] Must provide a REST endpoint that delivers a singleton resource in JSON.
     - The `/movie/{title}` endpoint returns a singleton resource in JSON.
-- [ ] Must provide a REST endpoint that allows search of 1 Oscar category and returns results containing the nominees in JSON.
+- [x] Must provide a REST endpoint that allows search of 1 Oscar category and returns results containing the nominees in JSON.
+    - The `/category/{name}` endpoint returns a collection resource of a specific Oscar category in JSON.
 - [x] Must provide a minimum level of documentation regarding access, input, and output to your API endpoints. 
     - API endpoint access documented in [README](README.md#Use).
 
@@ -39,8 +40,10 @@
 - [x] The results returned contain data which correlates the Oscar category results with additional data from an outside source such as OMDb, TMDb, TVDb etc. by providing a link to an external site for the movie.
     - OMDb is used when the singleton endpoint `/movie/{title}` is called. This provides a link to the IMDb page.
 - [ ] The search feature allows limiting results to a date range.
-- [ ] More than one category can be searched.
-- [ ] More than one endpoint that delivers a collection resource.
+- [x] More than one category can be searched.
+    - The `/category/{name}` category can search any of the Oscar categories listed [here](https://github.com/zedchance/oscars/wiki/Endpoints#category).
+- [x] More than one endpoint that delivers a collection resource.
+    - Both `/all` and `/category/{name}` return collection resources.
 - [ ] More than one endpoint that delivers a singleton resource.
 - [ ] GUI for the product (or portions thereof).
 - [ ] Well-designed HTML page documenting API endpoints and example inputs/outputs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# team-3 oscars
+# `team-3` oscars
 
-A REST API for searching for Oscar winning/nominated movies. Created by `team3` for CSC131 in Fall 2020.
+A REST API for searching for Oscar winning/nominated movies. Created by `team-3` for CSC131 in Fall 2020.
+
+- [Wiki](https://github.com/zedchance/oscars/wiki)
+- [How to use](https://github.com/zedchance/oscars/wiki/Endpoints) the API endpoints
+- [Deliverables](DELIVERABLES.md)
 
 ## Team
 
@@ -12,45 +16,3 @@ Nicholas Bailey | Dev
 Harnoor Singh | Dev
 Visoth Cheam | Dev
 Michael Lutsik | Dev
-
-## Deliverables
-
-Can be viewed [here](DELIVERABLES.md).
-
-## Use
-
-Run the `ApiApplication` file and visit `localhost:8080`.
-
-### Endpoints
-
-#### `/hello`
-
-This is a test endpoint to make sure that project is working correctly.
-It optionally takes a parameter `name`.
-
-For example:
-
-```
-localhost:8080/hello?name=World
-```
-
-#### `/all`
-
-This is an endpoint that returns all movies available.
-
-For example:
-
-```
-localhost:8080/all
-```
-
-#### `/movie`
-
-This is an endpoint that returns a specific movie by title.
-It uses the syntax `/movie/title`
-
-For example:
-
-```
-localhost:8080/movie/titanic
-```

--- a/src/main/java/api/CategoryNotFoundException.java
+++ b/src/main/java/api/CategoryNotFoundException.java
@@ -1,0 +1,13 @@
+package api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class CategoryNotFoundException extends RuntimeException
+{
+    public CategoryNotFoundException()
+    {
+        super("Category not found");
+    }
+}

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -68,7 +68,7 @@ public class Controller implements ErrorController
         {
             for (Award award : movie.getAwards())
             {
-                if (award.getCategory().contains(category.toUpperCase()))
+                if (award.getCategory().toUpperCase().contains(category.toUpperCase()))
                 {
                     if ("true".equalsIgnoreCase(winner) && award.isWinner()) matches.add(movie);
                     else if ("false".equalsIgnoreCase(winner) && !award.isWinner()) matches.add(movie);

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -68,7 +68,7 @@ public class Controller implements ErrorController
         {
             for (Award award : movie.getAwards())
             {
-                if (award.getCategory().contains(category))
+                if (award.getCategory().contains(category.toUpperCase()))
                 {
                     if ("true".equalsIgnoreCase(winner) && award.isWinner()) matches.add(movie);
                     else if ("false".equalsIgnoreCase(winner) && !award.isWinner()) matches.add(movie);

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -38,7 +38,7 @@ public class Controller implements ErrorController
     /**
      * An endpoint that returns a specific movie
      *
-     * @param title the title of the movie, use ?title=
+     * @param title the title of the movie
      * @return a Movie
      */
     @GetMapping("/movie/{title}")
@@ -47,6 +47,32 @@ public class Controller implements ErrorController
         Movie m = FetchFromCSV.certainMovie(title).get(0);
         m.updateFields();
         return m;
+    }
+
+    /**
+     * An endpoint that returns all movies that won an award
+     * in specified category. View all available categories
+     * in the wiki.
+     *
+     * @param category category to search for
+     * @return an ArrayList<Movie> of all movies containing award category
+     */
+    @GetMapping("/category/{category}")
+    public ArrayList<Movie> category(@PathVariable("category") String category)
+    {
+        ArrayList<Movie> all = FetchFromCSV.all();
+        ArrayList<Movie> matches = new ArrayList<>();
+        for (Movie movie: all)
+        {
+            for (Award award: movie.getAwards())
+            {
+                if (award.getCategory().contains(category))
+                {
+                    matches.add(movie);
+                }
+            }
+        }
+        return matches;
     }
 
     /**

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -55,20 +55,24 @@ public class Controller implements ErrorController
      * in the wiki.
      *
      * @param category category to search for
+     * @param winner optional boolean to specify if award was won or not
      * @return an ArrayList<Movie> of all movies containing award category
      */
     @GetMapping("/category/{category}")
-    public ArrayList<Movie> category(@PathVariable("category") String category)
+    public ArrayList<Movie> category(@PathVariable("category") String category,
+                                     @RequestParam(value = "winner", defaultValue = "none") String winner)
     {
         ArrayList<Movie> all = FetchFromCSV.all();
         ArrayList<Movie> matches = new ArrayList<>();
-        for (Movie movie: all)
+        for (Movie movie : all)
         {
-            for (Award award: movie.getAwards())
+            for (Award award : movie.getAwards())
             {
                 if (award.getCategory().contains(category))
                 {
-                    matches.add(movie);
+                    if ("true".equalsIgnoreCase(winner) && award.isWinner()) matches.add(movie);
+                    else if ("false".equalsIgnoreCase(winner) && !award.isWinner()) matches.add(movie);
+                    else if ("none".equals(winner)) matches.add(movie);
                 }
             }
         }


### PR DESCRIPTION
This adds the ability to search by Award category, for example:

```
localhost:8080/category/ACTOR
```

Also, I made the README a lot simpler and instead added a link to the wiki feature of GitHub. That way, we can edit the documentation for accessing the endpoints without introducing a bunch of commits and having to do PRs. I also did this so I could paste a list of the categories available there without making the README really long. Check out the wiki [here](https://github.com/zedchance/oscars/wiki), and check out the list of categories [here](https://github.com/zedchance/oscars/wiki/Endpoints#category).

If any of the categories don't look like they belong to a movie, let me know and I'll remove them from the list. (For example I removed the `HONORARY AWARD` one because it wasn't award to movies).