### PR TITLE
Duplicate fix on /movie endpoint

### DIFF
--- a/DELIVERABLES.md
+++ b/DELIVERABLES.md
@@ -24,7 +24,7 @@
     - [x] Instructor must receive invite to/location of project.
 - [x] Must implement AT LEAST one user story per sprint.
 - [x] Must incorporate unit testing for a minimum of 2 classes.
-    - Unit tests implemented for both the Movie class, and the Award class.
+    - [Unit tests](https://github.com/zedchance/oscars/tree/master/src/test/java/api) implemented for both the Movie class, and the Award class.
 
 ### Presentation
 
@@ -57,7 +57,7 @@
 - [ ] Incorporate Contextual Inquiry/Elicitation techniques to create visual persona(s) and develop additional personas.
     - As evidenced by notes taken from the inquiries and creation of additional visual persona(s) beyond the minimum (part of deliverable 2).
 - [x] Create mockups for proposed GUI (even if not implemented).
-    - ADD GUI MOCKUP LINK HERE.
+    - Mockups can be viewed [here](https://github.com/zedchance/oscars/wiki/Mockups).
 - [ ] Incorporate pair programing during one Sprint.
     - As evidenced by a 1-minute clip of a recording in-person or Use Together session with link included in final deliverable.
 - [ ] Incorporate one or more design patterns.

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -37,16 +37,36 @@ public class Controller implements ErrorController
     }
 
     /**
-     * An endpoint that returns a specific movie
+     * An endpoint that returns a specific movie. If two movies share the same title,
+     * the oldest is returned. To get a specific movie of a certain year, add the
+     * year paramter, i.e. /movie/titanic?year=1997
      *
      * @param title the title of the movie
      * @return a Movie
      * @throws MovieNotFoundException
      */
     @GetMapping("/movie/{title}")
-    public Movie movie(@PathVariable("title") String title) throws MovieNotFoundException
+    public Movie movie(@PathVariable("title") String title,
+                       @RequestParam(value = "year", defaultValue = "none") String year)
+            throws MovieNotFoundException
     {
-        Movie m = FetchFromCSV.certainMovie(title).get(0);
+        ArrayList<Movie> list = FetchFromCSV.certainMovie(title);
+        Movie m = null;
+        if (!"none".equals(year))
+        {
+            for (Movie movie: list)
+            {
+                if (movie.getYear().equalsIgnoreCase(year)) m = movie;
+            }
+        }
+        else
+        {
+            m = list.get(0);
+        }
+        if (m == null)
+        {
+            throw new MovieNotFoundException();
+        }
         m.updateFields();
         return m;
     }
@@ -54,7 +74,8 @@ public class Controller implements ErrorController
     /**
      * An endpoint that returns all movies that won an award
      * in specified category. View all available categories
-     * in the wiki.
+     * in the wiki. To specify if the movie won in that category, add the
+     * winner parameter, i.e. /category/music?winner=true
      *
      * @param category category to search for
      * @param winner   optional boolean to specify if award was won or not


### PR DESCRIPTION
Okay so the `/movie` endpoint will always return the oldest movie, if duplicate titles exist. To be able to get the specific title from a certain year the `year` option can be specified. (#12)

For example:

```
localhost:8080/movie/titanic
```

will return the 1953 version, and

```
localhost:8080/movie/titanic?year=1997
```

will return the 1997 version.

This keeps the `/movie` endpoint as a singleton resource, while allowing the ability to get the others when a title is duplicated.

Also: Updated DELIVERABLES with a link to the unit tests and mockups. Updated the wiki to clarify what happens when duplicates exist and how to use the `year` option.