### PR TITLE
CSV refactor

### DIFF
--- a/DELIVERABLES.md
+++ b/DELIVERABLES.md
@@ -11,7 +11,7 @@
 - [x] Must provide a REST endpoint that allows search of 1 Oscar category and returns results containing the nominees in JSON.
     - The `/category/{name}` endpoint returns a collection resource of a specific Oscar category in JSON.
 - [x] Must provide a minimum level of documentation regarding access, input, and output to your API endpoints. 
-    - API endpoint access documented in [README](README.md#Use).
+    - API endpoint access documented in [the wiki](https://github.com/zedchance/oscars/wiki/Endpoints).
 
 ### Process
 
@@ -19,7 +19,7 @@
 - [x] Must have one persona.
 - [x] Must store source code in a repository such as GitHub
     - [x] Instructor must receive invite to/location of repository.
-    - [ ] There must be evidence of ongoing repository activity for each sprint.
+    - [x] There must be evidence of ongoing repository activity for each sprint.
 - [x] Must use Flying Donut to track and adhere to Scrum Process
     - [x] Instructor must receive invite to/location of project.
 - [x] Must implement AT LEAST one user story per sprint.
@@ -39,33 +39,34 @@
 
 - [x] The results returned contain data which correlates the Oscar category results with additional data from an outside source such as OMDb, TMDb, TVDb etc. by providing a link to an external site for the movie.
     - OMDb is used when the singleton endpoint `/movie/{title}` is called. This provides a link to the IMDb page.
-- [ ] The search feature allows limiting results to a date range.
+- [x] The search feature allows limiting results to a date range.
+    - `/all` takes optional parameters to specify a year range. For example: `/all/1950` or `/all/1950/1955`.
 - [x] More than one category can be searched.
     - The `/category/{name}` category can search any of the Oscar categories listed [here](https://github.com/zedchance/oscars/wiki/Endpoints#category).
 - [x] More than one endpoint that delivers a collection resource.
-    - Both `/all` and `/category/{name}` return collection resources.
-- [ ] More than one endpoint that delivers a singleton resource.
-- [ ] GUI for the product (or portions thereof).
-- [ ] Well-designed HTML page documenting API endpoints and example inputs/outputs.
+    - `/all`, `/category/{name}`, and `/winner` return collection resources.
+- [x] More than one endpoint that delivers a singleton resource.
+    - The `/random` endpoint returns a singleton resource, a randomly selected movie.
+- [x] GUI for the product (or portions thereof).
+    - The GUI can be accessed at the root, `localhost:8080/`
+- [x] Well-designed HTML page documenting API endpoints and example inputs/outputs.
+    - A page documenting API endpoints, including example input and output, can be found [here](https://github.com/zedchance/oscars/wiki/Endpoints) in the wiki.
 
 ### Process
 
 - [ ] Incorporate test-driven development practice for one Sprint.
-    - As evidenced by timestamps on check in for test code vs. check in for implementation code.
-- [ ] Refactor code in a significant manner with a clear and stated goal for refactoring.
-    - As evidenced by an implemented story from the Product Backlog with corresponding work in the repository.
+- [x] Refactor code in a significant manner with a clear and stated goal for refactoring.
+    - The repeated code in `FetchFromCSV` was refactored in a manner that was tracked via Flying Donut #159. This was merged in [#26](https://github.com/zedchance/oscars/pull/26).
 - [ ] Incorporate Contextual Inquiry/Elicitation techniques to create visual persona(s) and develop additional personas.
-    - As evidenced by notes taken from the inquiries and creation of additional visual persona(s) beyond the minimum (part of deliverable 2).
 - [x] Create mockups for proposed GUI (even if not implemented).
     - Mockups can be viewed [here](https://github.com/zedchance/oscars/wiki/Mockups).
-- [ ] Incorporate pair programing during one Sprint.
-    - As evidenced by a 1-minute clip of a recording in-person or Use Together session with link included in final deliverable.
+- [x] Incorporate pair programing during one Sprint.
+    - Pair programming was performed during the development of PR [#30](https://github.com/zedchance/oscars/pull/30), video can be viewed [here]().
 - [ ] Incorporate one or more design patterns.
-    - Indicate in user story which design pattern for which class(es) and provide comments in code (checked in to repository).
 - [x] Adopt a coding standard and follow it.
     - The team adopted a coding standard, and enforced it via [these files](.idea/codeStyles).
 - [ ] Use a database to store and retrieve Oscar data using queries.
-- [ ] Analyze code using SonarQube or similar tool.
-    - As evidenced by screenshot of SonarQube analysis.
+- [x] Analyze code using SonarQube or similar tool.
+    - We analyzed our code using SonarQube, and documented it [here](https://github.com/zedchance/oscars/wiki/SonarQube-analysis).
 - [x] Explain and document obstacles encountered during the project and how those obstacles were handled.
     - All obstacles encountered by the team were documented/discussed using GitHub's issue/pull request system, the entire stream can be viewed [here](https://github.com/zedchance/oscars/issues?q=).

--- a/DELIVERABLES.md
+++ b/DELIVERABLES.md
@@ -61,7 +61,7 @@
 - [x] Create mockups for proposed GUI (even if not implemented).
     - Mockups can be viewed [here](https://github.com/zedchance/oscars/wiki/Mockups).
 - [x] Incorporate pair programing during one Sprint.
-    - Pair programming was performed during the development of PR [#30](https://github.com/zedchance/oscars/pull/30), video can be viewed [here](https://www.youtube.com/watch?v=8EGnCJyYC2s).
+    - Pair programming was performed during the development of PR [#30](https://github.com/zedchance/oscars/pull/30), video can be viewed [here](https://www.youtube.com/watch?v=Cvt6B0-nuSE).
 - [ ] Incorporate one or more design patterns.
 - [x] Adopt a coding standard and follow it.
     - The team adopted a coding standard, and enforced it via [these files](.idea/codeStyles).

--- a/DELIVERABLES.md
+++ b/DELIVERABLES.md
@@ -46,7 +46,7 @@
 - [x] More than one endpoint that delivers a collection resource.
     - `/all`, `/category/{name}`, and `/winner` return collection resources.
 - [x] More than one endpoint that delivers a singleton resource.
-    - The `/random` endpoint returns a singleton resource, a randomly selected movie.
+    - `/movie` and `/random` return singleton resources, a movie by title or a randomly selected movie, respectively.
 - [x] GUI for the product (or portions thereof).
     - The GUI can be accessed at the root, `localhost:8080/`
 - [x] Well-designed HTML page documenting API endpoints and example inputs/outputs.
@@ -61,7 +61,7 @@
 - [x] Create mockups for proposed GUI (even if not implemented).
     - Mockups can be viewed [here](https://github.com/zedchance/oscars/wiki/Mockups).
 - [x] Incorporate pair programing during one Sprint.
-    - Pair programming was performed during the development of PR [#30](https://github.com/zedchance/oscars/pull/30), video can be viewed [here]().
+    - Pair programming was performed during the development of PR [#30](https://github.com/zedchance/oscars/pull/30), video can be viewed [here](https://www.youtube.com/watch?v=8EGnCJyYC2s).
 - [ ] Incorporate one or more design patterns.
 - [x] Adopt a coding standard and follow it.
     - The team adopted a coding standard, and enforced it via [these files](.idea/codeStyles).

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>groupId</groupId>
     <artifactId>oscars</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 
     <dependencies>
         <dependency>

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -35,7 +35,7 @@ public class Controller implements ErrorController
     /**
      * An endpoint that returns all 4934 movies
      *
-     * @return an ArrayList<Movie> of all the movies
+     * @return a List<Movie> of all the movies
      */
     @GetMapping("/all")
     public List<Movie> all()
@@ -59,7 +59,7 @@ public class Controller implements ErrorController
     {
         ArrayList<Movie> matches = new ArrayList<>();
         Movie m = null;
-        for (Movie movie: ALL_MOVIES)
+        for (Movie movie : ALL_MOVIES)
         {
             if (movie.getTitle().equalsIgnoreCase(title))
             {
@@ -68,7 +68,7 @@ public class Controller implements ErrorController
         }
         if (!"none".equals(year))
         {
-            for (Movie movie: matches)
+            for (Movie movie : matches)
             {
                 if (movie.getYear().equalsIgnoreCase(year)) m = movie;
             }
@@ -93,12 +93,12 @@ public class Controller implements ErrorController
      *
      * @param category category to search for
      * @param winner   optional boolean to specify if award was won or not
-     * @return an ArrayList<Movie> of all movies containing award category
+     * @return a List<Movie> of all movies containing award category
      * @throws CategoryNotFoundException when category isn't found
      */
     @GetMapping("/category/{category}")
     public List<Movie> category(@PathVariable("category") String category,
-                                     @RequestParam(value = "winner", defaultValue = "none") String winner)
+                                @RequestParam(value = "winner", defaultValue = "none") String winner)
             throws CategoryNotFoundException
     {
         ArrayList<Movie> matches = new ArrayList<>();

--- a/src/main/java/api/Controller.java
+++ b/src/main/java/api/Controller.java
@@ -55,7 +55,6 @@ public class Controller implements ErrorController
     @GetMapping("/movie/{title}")
     public Movie movie(@PathVariable("title") String title,
                        @RequestParam(value = "year", defaultValue = "none") String year)
-            throws MovieNotFoundException
     {
         ArrayList<Movie> matches = new ArrayList<>();
         Movie m = null;
@@ -73,7 +72,7 @@ public class Controller implements ErrorController
                 if (movie.getYear().equalsIgnoreCase(year)) m = movie;
             }
         }
-        else
+        else if (!matches.isEmpty())
         {
             m = matches.get(0);
         }
@@ -99,7 +98,6 @@ public class Controller implements ErrorController
     @GetMapping("/category/{category}")
     public List<Movie> category(@PathVariable("category") String category,
                                 @RequestParam(value = "winner", defaultValue = "none") String winner)
-            throws CategoryNotFoundException
     {
         ArrayList<Movie> matches = new ArrayList<>();
         for (Movie movie : ALL_MOVIES)

--- a/src/main/java/api/FetchFromCSV.java
+++ b/src/main/java/api/FetchFromCSV.java
@@ -7,67 +7,6 @@ import java.util.*;
 
 public class FetchFromCSV
 {
-
-    public static ArrayList<Movie> certainMovie(String movieName)
-    {
-        String csvFile = "src/main/resources/KaggleData_the_oscar_award.csv";
-        String data = "";
-        String title;
-        String year;
-        String ceremony;
-        String category;
-        String name;
-        boolean winner;
-        ArrayList<Award> awards = new ArrayList<>();
-        ArrayList<Movie> movieData = new ArrayList<>();
-
-        try (BufferedReader br = new BufferedReader(new FileReader(csvFile)))
-        {
-            br.readLine(); //reads the first line of all the headers because we are not interested in it.
-            while ((data = br.readLine()) != null)
-            {
-                // use comma as separator
-                String[] movie = data.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
-
-                // checks to see if title is empty, if so, does not add to the movie array
-                if (!movie[5].equals("") && movie[5].equalsIgnoreCase(movieName))
-                {
-                    // Movie object
-                    title = Formatter.formatTitle(movie[5]);
-                    year = movie[0];
-                    ceremony = movie[2];
-                    // Award object
-                    category = movie[3];
-                    name = Formatter.formatName(movie[4]);
-                    winner = Boolean.parseBoolean(movie[6]);
-
-                    Movie one = (new Movie(year, title, ceremony));
-
-                    if (!movieData.contains(one))
-                    {
-                        movieData.add(one);
-                    }
-
-                    movieData.get(movieData.indexOf(one)).addAward(new Award(category, name, winner));
-                }
-            }
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-        }
-        // check to see if a match was found
-        if (movieData.size() == 0)
-        {
-            throw new MovieNotFoundException();
-        }
-        else
-        {
-            // System.out.println(movieData); // please keep for testing purposes
-            return movieData;
-        }
-    }
-
     public static ArrayList<Movie> all()
     {
         String csvFile = "src/main/resources/KaggleData_the_oscar_award.csv";
@@ -133,8 +72,7 @@ public class FetchFromCSV
         }
         else
         {
-            System.out.println(certainMovie(input));
+//            System.out.println(certainMovie(input));
         }
     }
-
 }

--- a/src/main/java/api/FetchFromCSV.java
+++ b/src/main/java/api/FetchFromCSV.java
@@ -1,15 +1,13 @@
 package api;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 import java.util.*;
 
 public class FetchFromCSV
 {
     public static ArrayList<Movie> all()
     {
-        String csvFile = "src/main/resources/KaggleData_the_oscar_award.csv";
+        String csvFile = "/KaggleData_the_oscar_award.csv";
         String data = "";
         String title;
         String year;
@@ -17,10 +15,10 @@ public class FetchFromCSV
         String category;
         String name;
         boolean winner;
-        ArrayList<Award> awards = new ArrayList<>();
         ArrayList<Movie> movieData = new ArrayList<>();
 
-        try (BufferedReader br = new BufferedReader(new FileReader(csvFile)))
+        InputStream in = FetchFromCSV.class.getResourceAsStream(csvFile);
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in)))
         {
             br.readLine(); //reads the first line of all the headers because we are not interested in it.
             while ((data = br.readLine()) != null)

--- a/src/main/java/api/FetchFromCSV.java
+++ b/src/main/java/api/FetchFromCSV.java
@@ -57,22 +57,4 @@ public class FetchFromCSV
         }
         return movieData;
     }
-
-    public static void main(String[] args) throws Exception
-    {
-        Scanner scan = new Scanner(System.in);
-
-        System.out.println("Movie Name: ");
-
-        String input = scan.nextLine();
-
-        if (input.equalsIgnoreCase("all"))
-        {
-            all();
-        }
-        else
-        {
-//            System.out.println(certainMovie(input));
-        }
-    }
 }

--- a/src/main/java/api/Movie.java
+++ b/src/main/java/api/Movie.java
@@ -1,6 +1,7 @@
 package api;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class Movie
 {
@@ -170,7 +171,15 @@ public class Movie
     @Override
     public boolean equals(Object o)
     {
+        if (o == null) return false;
+        if (this.getClass() != o.getClass()) return false;
         Movie a = (Movie) o;
         return this.title.equals(a.title) && this.year.equals(a.year);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(title, year, ceremony, awards, genre, plot, poster, website, error);
     }
 }

--- a/src/main/resources/KaggleData_the_oscar_award.csv
+++ b/src/main/resources/KaggleData_the_oscar_award.csv
@@ -8,8 +8,7 @@ year_film,year_ceremony,ceremony,category,name,film,winner
 1927,1928,1,ART DIRECTION,William Cameron Menzies,The Dove;,True
 1927,1928,1,ART DIRECTION,Harry Oliver,7th Heaven,False
 1927,1928,1,CINEMATOGRAPHY,George Barnes,The Devil Dancer;,False
-1927,1928,1,CINEMATOGRAPHY,Charles Rosher,Sunrise,True
-1927,1928,1,CINEMATOGRAPHY,Karl Struss,Sunrise,True
+1927,1928,1,CINEMATOGRAPHY,"Charles Rosher, Karl Struss",Sunrise,True
 1927,1928,1,DIRECTING (Comedy Picture),Lewis Milestone,Two Arabian Knights,True
 1927,1928,1,DIRECTING (Comedy Picture),Ted Wilde,Speedy,False
 1927,1928,1,DIRECTING (Dramatic Picture),Frank Borzage,7th Heaven,True


### PR DESCRIPTION
Okay so I refactored `FetchFromCSV` and `Controller` so now the csv file is only read once when the project is started. This way it doesn't have to continually read the csv file for each subsequent endpoint request. This also makes our OMDb calls more efficient because it will only call on a movie once, then it stores it. The next time around it doesn't need to call it again because it sees in memory that the fields are already populated.

I tracked this refactor in the Flying Donut user story 159 (in Sprint 3).

Now, before this is merged in:
 - [x] I want to merge in @Mikelutsik's `won_oscar` branch because this will have conflicts with that branch (in `Controller`)
 - [x] Update `DELIVERABLES.md`
 - [x] Update version to v0.1.1 in `pom.xml`

Also:
- `FetchFromCSV` now reads the file using a InputStream so that it can properly find the csv file when running from a jar. This makes the jar file deployable!
- Desmelled a couple of things in `Movie` and `Controller` that were discovered by SonarQube.
- Made a fix to the csv file to close #21.